### PR TITLE
Adds scripts to compile results into a spreadsheet for analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,7 @@ ELC_LowTrans**
 ELC_MidTrans_LowDC_NoIRA/
 TEST_LA_CO2_MidTrans_HighDC_NoIRA
 ELC_MidTrans_HighDC_NoIRA
+
+analysis/*
+!*.gitkeep
+.bat

--- a/README.md
+++ b/README.md
@@ -57,4 +57,10 @@ git pull origin main
 > You cannot pull changes or execute any commands in the same session that is running the visualizer.
 > In other words, you must shut down the visualizer, pull the changes, and restart it for the changes to take effect.
 
+# Compiling results into a spreadsheet for analysis
 
+There are two scripts which can be run sequentially to aid in analyzing results.
+
+1. **Run `results_list.py` to create a matrix of results**, with rows for scenarios and columns for metrics (generation, capacity, emissions, etc). "TRUE" indicates that an output file exists for the given combination of scenario and metric.
+2. **Edit `analysis/results_list.csv` to limit which files will be included in the final spreadsheet.** This can be acomplished by deleting entire rows/columns, and/or deleting "TRUE" from specific combinations that aren't needed. Limiting which files are included will greatly reduce the processing time and the file size of the final result. Very large files may be unstable.
+3. **Run results_spreadsheet.py to create a spreadsheet with the desired results.** If there is an existing version of `results_spreadsheet.xlsx`, the script will append it, and overwrite existing sheets. Otherwise, a new copy will be created.

--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - numpy
   - tqdm
   - openpyxl
+  - xlsxwriter
   - pip:
     - streamlit
     - pygwalker

--- a/launch_visualizer.bat
+++ b/launch_visualizer.bat
@@ -1,0 +1,3 @@
+cd /d %~dp0
+call conda activate reeds-viz
+streamlit run visualizer.py

--- a/results_list.py
+++ b/results_list.py
@@ -1,0 +1,37 @@
+import os
+import csv
+
+# Path to results
+base_path = "./results/fy25"
+
+# Get list of all scenario folders (exclude files)
+scenario_folders = [f for f in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, f))]
+
+# Collect all unique CSV filenames across all scenarios
+csv_files = set()
+for scenario in scenario_folders:
+    scenario_path = os.path.join(base_path, scenario)
+    for f in os.listdir(scenario_path):
+        if f.endswith(".csv"):
+            csv_files.add(f)
+
+csv_files = sorted(list(csv_files))  # sort columns alphabetically
+
+# Write summary CSV
+output_file = "./analysis/results_list.csv"
+with open(output_file, "w", newline="") as outcsv:
+    writer = csv.writer(outcsv)
+
+    # Header row: Scenario + filenames
+    writer.writerow(["Scenario"] + csv_files)
+
+    # Rows: scenario and whether each file exists
+    for scenario in scenario_folders:
+        row = [scenario]
+        scenario_path = os.path.join(base_path, scenario)
+        existing_files = set(os.listdir(scenario_path))
+        for f in csv_files:
+            row.append("TRUE" if f in existing_files else "")
+        writer.writerow(row)
+
+print(f"Summary written to {output_file}")

--- a/results_list.py
+++ b/results_list.py
@@ -23,7 +23,7 @@ with open(output_file, "w", newline="") as outcsv:
     writer = csv.writer(outcsv)
 
     # Header row: Scenario + filenames
-    writer.writerow(["Scenario"] + csv_files)
+    writer.writerow(["scenario"] + csv_files)
 
     # Rows: scenario and whether each file exists
     for scenario in scenario_folders:

--- a/results_spreadsheet.py
+++ b/results_spreadsheet.py
@@ -53,10 +53,18 @@ def clean_and_aggregate(df, scenario, region_to_state):
     df.insert(0, "scenario", scenario)
 
     # aggregate value
+    # Identify numeric columns to aggregate
     if "value" in df.columns:
-        df["value"] = pd.to_numeric(df["value"], errors="coerce")
-        group_cols = [c for c in df.columns if c != "value"]
-        df = df.groupby(group_cols, as_index=False)["value"].sum()
+        agg_cols = ["value"]
+    elif {"tons", "md", "damage_$", "mortality"}.issubset(df.columns):
+        agg_cols = ["tons", "md", "damage_$", "mortality"]
+    else:
+        agg_cols = []
+
+    if agg_cols:
+        # Group by all non-aggregated columns
+        group_cols = [c for c in df.columns if c not in agg_cols]
+        df = df.groupby(group_cols, as_index=False)[agg_cols].sum()
     else:
         df = df.drop_duplicates()
 

--- a/results_spreadsheet.py
+++ b/results_spreadsheet.py
@@ -108,13 +108,13 @@ if os.path.exists(output_excel):
     if_exists = "replace"
     print(f"Updating existing file: {output_excel}")
 else:
-    # Prefer xlsxwriter for new files, fall back to openpyxl
+    # Prefer the faster xlsxwriter for new files, fall back to openpyxl
     try:
         import xlsxwriter
         excel_engine = "xlsxwriter"
     except ImportError:
         excel_engine = "openpyxl"
-        print("⚠️ xlsxwriter not found, using openpyxl")
+        print("xlsxwriter not found, using openpyxl")
     mode = "w"
     if_exists = None
     print(f"Creating new file: {output_excel}")

--- a/results_spreadsheet.py
+++ b/results_spreadsheet.py
@@ -54,10 +54,12 @@ def clean_and_aggregate(df, scenario, region_to_state):
 
     # aggregate value
     # Identify numeric columns to aggregate
+    health_cols = ["tons", "md", "damage_$", "mortality"]
+    
     if "value" in df.columns:
         agg_cols = ["value"]
-    elif {"tons", "md", "damage_$", "mortality"}.issubset(df.columns):
-        agg_cols = ["tons", "md", "damage_$", "mortality"]
+    elif set(health_cols).issubset(df.columns):
+        agg_cols = health_cols
     else:
         agg_cols = []
 
@@ -82,18 +84,15 @@ tabs = {csv_name: [] for csv_name in csv_types}
 for _, row in tqdm(
     summary_df.iterrows(), total=len(summary_df), desc="Processing scenarios"
 ):
-    scenario = row["Scenario"]
+    scenario = row["scenario"]
     for csv_name in csv_types:
         csv_path = os.path.join(base_path, scenario, csv_name)
-        if not os.path.exists(csv_path):
-            continue
         try:
             df = pd.read_csv(csv_path)
             df = clean_and_aggregate(df, scenario, region_to_state)
             tabs[csv_name].append(df)
-        except Exception as e:
+        except FileNotFoundError as e:
             print(f"Error processing {csv_path}: {e}")
-
 # === Write Excel ===
 total_rows = 0
 for dfs in tabs.values():

--- a/results_spreadsheet.py
+++ b/results_spreadsheet.py
@@ -1,0 +1,87 @@
+import os
+import pandas as pd
+from tqdm import tqdm
+
+# Paths
+base_path = "./results/fy25"
+summary_file = "./analysis/results_list.csv"
+output_excel = "./analysis/results_spreadsheet.xlsx"
+mapping_file = "./data/county2zone.csv"
+
+# Technologies to collapse
+agg_techs = ['wind-ons','wind-ofs','pv','csp','hyd','egs','coal','gas']
+
+# === Helpers ===
+def load_region_map(path):
+    df = pd.read_csv(path)
+    if "ba" in df.columns and "r" not in df.columns:
+        df = df.rename(columns={"ba": "r"})
+    return df.set_index("r")["state"].to_dict()
+
+def clean_and_aggregate(df, scenario, region_to_state):
+    # Normalize headers
+    df.columns = df.columns.str.strip().str.lower()
+
+    # r -> state
+    if "r" in df.columns:
+        df["state"] = df["r"].map(region_to_state)
+        df = df.drop(columns=["r"])
+
+    # collapse i
+    if "i" in df.columns:
+        df["i"] = df["i"].astype(str).str.strip().str.lower()
+        for tech in agg_techs:
+            if tech in ["coal", "gas"]:
+                df.loc[df["i"].str.contains(tech, case=False, na=False) & ~df["i"].str.contains("ccs", case=False, na=False), "i"] = tech
+                df.loc[df["i"].str.contains(tech, case=False, na=False) & df["i"].str.contains("ccs", case=False, na=False), "i"] = f"{tech}_ccs"
+            else:
+                df.loc[df["i"].str.contains(tech, case=False, na=False), "i"] = tech
+
+    # add Scenario
+    df.insert(0, "scenario", scenario)
+
+    # aggregate value
+    if "value" in df.columns:
+        df["value"] = pd.to_numeric(df["value"], errors="coerce")
+        group_cols = [c for c in df.columns if c != "value"]
+        df = df.groupby(group_cols, as_index=False)["value"].sum()
+    else:
+        df = df.drop_duplicates()
+
+    return df
+
+# === Main ===
+summary_df = pd.read_csv(summary_file)
+region_to_state = load_region_map(mapping_file)
+csv_types = [c for c in summary_df.columns if c.lower() != "scenario"]
+
+tabs = {csv_name: [] for csv_name in csv_types}
+
+# Wrap scenario loop in tqdm progress bar
+for _, row in tqdm(summary_df.iterrows(), total=len(summary_df), desc="Processing scenarios"):
+    scenario = row["Scenario"]
+    for csv_name in csv_types:
+        csv_path = os.path.join(base_path, scenario, csv_name)
+        if not os.path.exists(csv_path):
+            continue
+        try:
+            df = pd.read_csv(csv_path)
+            df = clean_and_aggregate(df, scenario, region_to_state)
+            tabs[csv_name].append(df)
+        except Exception as e:
+            print(f"Error processing {csv_path}: {e}")
+
+# === Write Excel ===
+total_rows = 0
+for dfs in tabs.values():
+    if dfs:
+        total_rows += sum(len(df) for df in dfs)
+print(f"\nTotal rows across all sheets: {total_rows:,}\n")
+with pd.ExcelWriter(output_excel, engine="xlsxwriter") as writer:
+    for csv_name, dfs in tqdm(tabs.items(), desc="Writing Excel"):
+        if dfs:
+            combined = pd.concat(dfs, ignore_index=True)
+            sheet_name = os.path.splitext(csv_name)[0][:31]
+            combined.to_excel(writer, sheet_name=sheet_name, index=False)
+
+print(f"\nWrote {output_excel}")


### PR DESCRIPTION
Run `results_list.py` first to create a csv table indexing all possible results -- scenarios in rows and output files in columns. Edit this file to remove scenarios and output files that are not needed, then run `results_spreadsheet.py` to create a single spreadsheet with all of the selected results compiled, with one sheet per output file and scenarios combined in each sheet. If the spreadsheet already exists the script will add or overwrite sheets as needed.

Adds no new dependencies to the repo, but will run faster when creating a new spreadsheet if xlsxwriter is installed.